### PR TITLE
travis: update CI to use latest go releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ dist: focal
 language: go
 
 go:
-  - "1.14"
-  - "1.15"
+  - "1.14.x"
+  - "1.15.x"
   - tip


### PR DESCRIPTION
# before

https://travis-ci.com/github/xyproto/algernon/jobs/381179026#L187-L188
```
$ go version
go version go1.14 linux/amd64
```

# after

https://travis-ci.com/github/chenrui333/algernon/jobs/381513533#L187-L188
```
$ go version
go version go1.14.8 linux/amd64
```