### PR TITLE
Time Support for MSSQL

### DIFF
--- a/lua/mssql/mssql.go
+++ b/lua/mssql/mssql.go
@@ -3,6 +3,7 @@ package mssql
 import (
 	"database/sql"
 	"fmt"
+    "time"
 	"strings"
 	"sync"
 
@@ -55,6 +56,9 @@ func (w *LValueWrapper) Scan(value interface{}) error {
 
 	case []byte:
 		*w = LValueWrapper{lua.LString(string(v))}
+  
+    case time.Time:
+    	*w = LValueWrapper{lua.LNumber(float64(v.Unix()))}
 
 	default:
 		return fmt.Errorf("unable to scan type %T into lua value wrapper", value)

--- a/lua/mssql/mssql.go
+++ b/lua/mssql/mssql.go
@@ -3,7 +3,7 @@ package mssql
 import (
 	"database/sql"
 	"fmt"
-    "time"
+	"time"
 	"strings"
 	"sync"
 

--- a/lua/mssql/mssql.go
+++ b/lua/mssql/mssql.go
@@ -57,8 +57,8 @@ func (w *LValueWrapper) Scan(value interface{}) error {
 	case []byte:
 		*w = LValueWrapper{lua.LString(string(v))}
   
-    case time.Time:
-    	*w = LValueWrapper{lua.LNumber(float64(v.Unix()))}
+	case time.Time:
+		*w = LValueWrapper{lua.LNumber(float64(v.Unix()))}
 
 	default:
 		return fmt.Errorf("unable to scan type %T into lua value wrapper", value)


### PR DESCRIPTION
Adds support for parsing times/date-times that come from MSSQL.  The resulting unix timestamp can then be processed by the builtin functions in Lua's OS package.