### PR TITLE
Roll back goja-babel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/jvatic/goja-babel v0.0.0-20210615124441-ff3b3c2be80c
+	github.com/jvatic/goja-babel v0.0.0-20210308004931-b9e24388e7b1
 	github.com/lib/pq v1.10.2
 	github.com/lucas-clemente/quic-go v0.19.2
 	github.com/marten-seemann/qtls-go1-15 v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,9 @@ github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55k
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 h1:Izz0+t1Z5nI16/II7vuEo/nHjodOg0p7+OiDpjX5t1E=
 github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
-github.com/dop251/goja v0.0.0-20210614154742-14a1ffa82844 h1:AAIne7C4tTmJP3NA+5YKt+c24T/vn4LDmYtRKQMXoCc=
-github.com/dop251/goja v0.0.0-20210614154742-14a1ffa82844/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
+github.com/dop251/goja v0.0.0-20210227132020-101e13ab2c34/go.mod h1:Mw6PkjjMXWbTj+nnj4s3QPXq1jaT0s5pC0iFD4+BOAA=
+github.com/dop251/goja v0.0.0-20210427212725-462d53687b0d h1:enuVjS1vVnToj/GuGZ7QegOAIh1jF340Sg6NXcoMohs=
+github.com/dop251/goja v0.0.0-20210427212725-462d53687b0d/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
 github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7/go.mod h1:hn7BA7c8pLvoGndExHudxTDKZ84Pyvv+90pbBjbTz0Y=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385 h1:clC1lXBpe2kTj2VHdaIu9ajZQe4kcEY9j0NsnDDBZ3o=

--- a/vendor/github.com/jvatic/goja-babel/.gitignore
+++ b/vendor/github.com/jvatic/goja-babel/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+babel.js

--- a/vendor/github.com/jvatic/goja-babel/babel.go
+++ b/vendor/github.com/jvatic/goja-babel/babel.go
@@ -1,7 +1,6 @@
 package babel
 
 import (
-	_ "embed"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -35,15 +34,6 @@ func Init(poolSize int) (err error) {
 		globalpool = make(chan *babelTransformer, poolSize)
 		for i := 0; i < poolSize; i++ {
 			vm := goja.New()
-
-			// define console.{log|error|warn} so loading babel doesn't error
-			logFunc := func(goja.FunctionCall) goja.Value { return nil }
-			vm.Set("console", map[string]func(goja.FunctionCall) goja.Value{
-				"log":   logFunc,
-				"error": logFunc,
-				"warn":  logFunc,
-			})
-
 			transformFn, e := loadBabel(vm)
 			if e != nil {
 				err = e
@@ -98,12 +88,13 @@ func getTransformer() (*babelTransformer, error) {
 	}
 }
 
-//go:embed babel.js
-var babelData string
-
 func compileBabel() error {
-	var err error
-	babelProg, err = goja.Compile("babel.js", babelData, false)
+	babelData, err := _Asset("babel.js")
+	if err != nil {
+		return err
+	}
+
+	babelProg, err = goja.Compile("babel.js", string(babelData), false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Just reverts to the commit we had in go.mod before https://github.com/xyproto/algernon/commit/6a3c23d6722c393d99171f1aee84d6f91fdcbcf8