### PR TITLE
Use a letsencrypt flag for using CertMagic and Let's Encrypt

### DIFF
--- a/engine/config.go
+++ b/engine/config.go
@@ -248,7 +248,8 @@ type Config struct {
 	// Redirect HTTP traffic to HTTPS
 	redirectHTTP bool
 
-	// CertMagic is enabled if one or more CertMagic domains are given
+	// Use CertMagic and Let's Encrypt for all directories in the given directory that contains a "."
+	useCertMagic     bool
 	certMagicDomains []string
 }
 

--- a/engine/flags.go
+++ b/engine/flags.go
@@ -506,11 +506,10 @@ func (ac *Config) handleFlags(serverTempDir string) {
 			//log.Infof("Looping over %v files", len(files))
 			for _, f := range files {
 				basename := filepath.Base(f.Name())
-				if f.Mode().IsDir() && strings.Contains(basename, ".") && !strings.HasPrefix(basename, ".") && !strings.HasSuffix(basename, ".old") {
-					//log.Infof("Accepting directory %s", basename)
+				dirOrSymlink := f.Mode().IsDir || ((f.Mode() & os.ModeSymlink) == os.ModeSymlink)
+				// TODO: Confirm that the symlink is a symlink to a directory, if it's a symlink
+				if dirOrSymlink && strings.Contains(basename, ".") && !strings.HasPrefix(basename, ".") && !strings.HasSuffix(basename, ".old") {
 					ac.certMagicDomains = append(ac.certMagicDomains, basename)
-				} else if (f.Mode() & os.ModeSymlink) == os.ModeSymlink {
-					//log.Infof("Accepting symlink %s", basename)
 				} else {
 					//log.Infof("Rejecting %s", basename)
 				}

--- a/engine/flags.go
+++ b/engine/flags.go
@@ -510,13 +510,7 @@ func (ac *Config) handleFlags(serverTempDir string) {
 				// TODO: Confirm that the symlink is a symlink to a directory, if it's a symlink
 				if dirOrSymlink && strings.Contains(basename, ".") && !strings.HasPrefix(basename, ".") && !strings.HasSuffix(basename, ".old") {
 					ac.certMagicDomains = append(ac.certMagicDomains, basename)
-				} else {
-					//log.Infof("Rejecting %s", basename)
 				}
-			}
-			//log.Info("Using CertMagic for these domains:")
-			for _, domain := range ac.certMagicDomains {
-				log.Info(domain)
 			}
 			// Using Let's Encrypt implies --domain, to search for suitable directories in the directory to be served
 			ac.serverAddDomain = true

--- a/engine/flags.go
+++ b/engine/flags.go
@@ -506,7 +506,7 @@ func (ac *Config) handleFlags(serverTempDir string) {
 			//log.Infof("Looping over %v files", len(files))
 			for _, f := range files {
 				basename := filepath.Base(f.Name())
-				dirOrSymlink := f.Mode().IsDir || ((f.Mode() & os.ModeSymlink) == os.ModeSymlink)
+				dirOrSymlink := f.Mode().IsDir() || ((f.Mode() & os.ModeSymlink) == os.ModeSymlink)
 				// TODO: Confirm that the symlink is a symlink to a directory, if it's a symlink
 				if dirOrSymlink && strings.Contains(basename, ".") && !strings.HasPrefix(basename, ".") && !strings.HasSuffix(basename, ".old") {
 					ac.certMagicDomains = append(ac.certMagicDomains, basename)

--- a/engine/serve.go
+++ b/engine/serve.go
@@ -154,8 +154,11 @@ func (ac *Config) Serve(mux *http.ServeMux, done, ready chan bool) error {
 	case ac.useCertMagic:
 		if len(ac.certMagicDomains) == 0 {
 			log.Warnln("Found no directories looking like domains in the given directory.")
+		} else if len(ac.certMagicDomains) == 1 {
+			log.Infof("Serving one domain with CertMagic: %s", ac.certMagicDomains[0])
+		} else {
+			log.Infof("Serving %d domains with CertMagic: %s", len(ac.certMagicDomains), strings.Join(ac.certMagicDomains, ", "))
 		}
-		log.Infof("Serving %d domains with CertMagic", len(ac.certMagicDomains))
 		mut.Lock()
 		servingHTTPS = true
 		mut.Unlock()


### PR DESCRIPTION
Use the `--letsencrypt` flag to use Let's Encrypt for all directories that look like domains that can be found in the directory that are being served. This also enables `--domain`.