### PR TITLE
Enhancement: manage handle.lua as in issue #95

### DIFF
--- a/engine/dirhandler.go
+++ b/engine/dirhandler.go
@@ -1,4 +1,3 @@
-package engine
 
 // Directory Index
 
@@ -136,6 +135,20 @@ func (ac *Config) DirPage(w http.ResponseWriter, req *http.Request, rootdir, dir
 			return
 		}
 	}
+
+	// Serve handle.lua, if found in ancestors
+	var ancestor string
+	ancestor = filepath.Dir(dirname)
+	for true {
+		filename= filepath.Join(ancestor, "handler.lua")
+		if ac.fs.Exists(filename) {
+			ac.FilePage(w, req, filename, ac.defaultLuaDataFilename)
+			return
+		}
+		if ancestor == "." { break }
+		ancestor= filepath.Dir(ancestor)
+	}
+
 
 	// Serve a directory listing if no index file is found
 	ac.DirectoryListing(w, req, rootdir, dirname, theme)


### PR DESCRIPTION
handle.lua files work as index.lua,
but "cover" also subtree
until "shadowed" by another handle.lua