### PR TITLE
Support reverse proxies

### DIFF
--- a/engine/flags.go
+++ b/engine/flags.go
@@ -57,6 +57,7 @@ func (ac *Config) handleFlags(serverTempDir string) {
 	flag.StringVar(&ac.redisAddr, "redis", "", "Redis [host][:port] (ie \""+ac.defaultRedisColonPort+"\")")
 	flag.IntVar(&ac.redisDBindex, "dbindex", 0, "Redis database index")
 	flag.StringVar(&ac.serverConfScript, "conf", "serverconf.lua", "Server configuration")
+	flag.StringVar(&ac.serverConfStatic, "sconf", "", "Static (non-lua) server configuration")
 	flag.StringVar(&ac.serverLogFile, "log", "", "Server log file")
 	flag.StringVar(&ac.internalLogFilename, "internal", os.DevNull, "Internal log file")
 	flag.BoolVar(&ac.serveJustHTTP2, "http2only", false, "Serve HTTP/2, not HTTPS + HTTP/2")

--- a/samples/static-config.json
+++ b/samples/static-config.json
@@ -1,0 +1,7 @@
+{
+  "reverse_proxies": [
+    {"path_prefix": "/api", "endpoint": "http://localhost:8000"},
+    {"path_prefix": "/api/auth", "endpoint": "http://localhost:8100"}
+
+  ]
+}

--- a/utils/prefixmatch.go
+++ b/utils/prefixmatch.go
@@ -1,0 +1,86 @@
+/*
+ * a data structure to test a string against a set of prefixes
+ */
+
+package utils
+
+import (
+	"fmt"
+)
+
+type Node struct {
+	IsTerminal bool
+	Children   map[rune]*Node
+}
+
+func (node *Node) GetChild(c rune) *Node {
+	ret, found := node.Children[c]
+	if found {
+		return ret
+	} else {
+		return nil
+	}
+}
+
+type PrefixMatch struct {
+	root Node
+}
+
+func (pm *PrefixMatch) Build(prefixes []string) {
+
+	//pm.root.Value = ""
+	for _, prefix := range prefixes {
+		current := &pm.root
+		for i, char := range prefix {
+			if current.Children == nil {
+				current.Children = make(map[rune]*Node)
+			}
+			_, exists := current.Children[char]
+			if !exists {
+				node := new(Node)
+				node.IsTerminal = i == len(prefix)-1
+				current.Children[char] = node
+				//fmt.Printf("adding %c -> %p\n", char, current.GetChild(char))
+			}
+			current, _ = current.Children[char]
+		}
+	}
+}
+
+func (pm *PrefixMatch) Match(str string) []string {
+	result := make([]string, 0)
+	pm.match(str, &pm.root, "", &result)
+	return result
+}
+
+func (pm *PrefixMatch) match(str string, start *Node, path string, found *[]string) {
+	if start.IsTerminal {
+		*found = append(*found, path)
+	}
+	if len(str) == 0 {
+		return
+	}
+	for char, child := range start.Children {
+		if string(str[0]) != string(char) {
+			return
+		}
+		pm.match(str[1:], child, path+string(char), found)
+	}
+}
+
+func (pm *PrefixMatch) PPrint(args ...*Node) {
+	var start *Node
+	if len(args) == 0 {
+		start = &pm.root
+	} else {
+		start = args[0]
+	}
+	fmt.Printf("%p:\n", start)
+	for char, node := range start.Children {
+		fmt.Printf("|-- %c: %p\n", char, node)
+	}
+	fmt.Printf("\n")
+	for _, node := range start.Children {
+		pm.PPrint(node)
+	}
+}

--- a/utils/prefixmatch_test.go
+++ b/utils/prefixmatch_test.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bmizerany/assert"
+)
+
+func TestPrefixMatch(t *testing.T) {
+	pm := PrefixMatch{}
+	pm.Build([]string{"/api", "/api/auth", "blog"})
+	//pm.PPrint()
+	//fmt.Printf("match(api) = %+v\n", pm.Match("api"))
+	assert.Equal(t, pm.Match("/api"), []string{"/api"})
+	assert.Equal(t, pm.Match("/api/index.html"), []string{"/api"})
+	assert.Equal(t, pm.Match("/api/auth"), []string{"/api", "/api/auth"})
+	assert.Equal(t, pm.Match("/api/auth/1234"), []string{"/api", "/api/auth"})
+	//fmt.Printf("match(api/auth) = %+v\n", pm.Match("api/auth"))
+	fmt.Printf("match(233) = %+v\n", pm.Match("233"))
+}


### PR DESCRIPTION
As rightfully requested in #93 . With reverse proxies, `algernon` can replace `nginx` in certain use cases.

I did not see why this config should be dynamically set in Lua, so I added a static configuration flag. This setup might also be useful for other config options. I'm open to change that though if needed.