### PR TITLE
fix: potential nil pointer dereference in lua plugin code

### DIFF
--- a/plugins/py/main.py
+++ b/plugins/py/main.py
@@ -113,8 +113,10 @@ def main():
     # Build the Lua RPC namespace for methods that starts with an uppercase letter
     for name in dir(rpc):
       if name[0].isupper():
-        setattr(rpc, "Lua." + name, getattr(rpc, name, None))
-       
+        method = getattr(rpc, name, None)
+        if callable(method):
+          setattr(rpc, "Lua." + name, method)
+        
     line = sys.stdin.readline()
 
     # The handling of lines is asynchronous,


### PR DESCRIPTION
## Summary

In the main() function, the code iterates through dir(rpc) and sets attributes on rpc with names that start with uppercase letters. However, if getattr(rpc, name, None) returns None (which can happen for methods that don't exist or are not callable), the setattr will set a None value. Later, when these methods are called from Lua, they will attempt to call None, causing a runtime panic. This is a critical bug that will crash the plugin when any such method is invoked.

## Changes

- `plugins/py/main.py`

"Add a check to ensure that getattr returns a callable before setting it: `if callable(getattr(rpc, name, None)): setattr(rpc, "Lua." + name, getattr(rpc, name, None))`"
