### PR TITLE
feat: allow SIGUSR2 to clear the cache

### DIFF
--- a/platformdep/signals_unix.go
+++ b/platformdep/signals_unix.go
@@ -8,12 +8,12 @@ import (
 	"syscall"
 )
 
-// SetupSignals installs a SIGUSR1 handler that invokes clearCacheFunction in
+// SetupSignals installs SIGUSR1/SIGUSR2 handlers that invoke clearCacheFunction in
 // a goroutine. printFunction is used to log the received signal.
 func SetupSignals(clearCacheFunction func(), printFunction func(format string, args ...any)) {
-	// Listen for SIGUSR1 to clear the cache
+	// Listen for SIGUSR1 and SIGUSR2 to clear the cache
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGUSR1)
+	signal.Notify(signals, syscall.SIGUSR1, syscall.SIGUSR2)
 	go func() {
 		for {
 			// Wait for a signal of the type given to signal.Notify


### PR DESCRIPTION
I've updated the signal handling to also listen for SIGUSR2, allowing it to trigger a cache clear just like SIGUSR1. This fulfills a TODO item and provides an additional way to clear the cache without restarting the server.